### PR TITLE
Fixed: php8 Warning: Undefined array key "reference"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,10 @@
         "vanderlee/syllable": "^1.5"
     },
     "require-dev": {
-        "contao/core-bundle": "4.4.*",
-        "contao/test-case": "1.1.*",
+        "contao/test-case": "1.1.* || ^2 || ^3 || ^4",
         "contao/manager-plugin": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.2",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
         "php-coveralls/php-coveralls": "^2.0",
@@ -51,5 +50,12 @@
     },
     "extra": {
         "contao-manager-plugin": "HeimrichHannot\\HyphenatorBundle\\ContaoManager\\Plugin"
+    },
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "php-http/discovery": false,
+            "contao/manager-plugin": true
+        }
     }
 }

--- a/src/Hyphenator/FrontendHyphenator.php
+++ b/src/Hyphenator/FrontendHyphenator.php
@@ -13,6 +13,8 @@ use Contao\PageModel;
 use Contao\StringUtil;
 use HeimrichHannot\HyphenatorBundle\Source\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Vanderlee\Syllable\Syllable;
 use Wa72\HtmlPageDom\HtmlPageCrawler;
 
@@ -32,9 +34,10 @@ class FrontendHyphenator
     /**
      * Request constructor.
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, ParameterBagInterface $parameterBag)
     {
         $this->container = $container;
+        $this->parameterBag = $parameterBag;
     }
 
     public function hyphenate($strBuffer)
@@ -72,7 +75,9 @@ class FrontendHyphenator
 
         $h = new Syllable($language);
 
-        $source = new File($language, __DIR__.'/../../../../vanderlee/syllable/languages', [
+        $rootPath = $this->parameterBag->get('kernel.project_dir');
+
+        $source = new File($language, $rootPath . '/vendor/vanderlee/syllable/languages', [
             $language => [$GLOBALS['TL_CONFIG']['hyphenator_hyphenedLeftMin'], $GLOBALS['TL_CONFIG']['hyphenator_hyphenedRightMin']],
         ]);
 

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -31,7 +31,7 @@ $fields = [
         'default' => 'inactive',
         'exclude' => true,
         'options' => ['active', 'inactive'],
-        'reference' => $GLOBALS['TL_LANG']['tl_page']['reference']['hyphenation'],
+        'reference' => $GLOBALS['TL_LANG']['tl_page']['reference']['hyphenation'] ?? null,
         'eval' => ['includeBlankOption' => true, 'tl_class' => 'w50'],
         'sql' => "char(8) NOT NULL default ''",
     ],

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -31,7 +31,7 @@ $fields = [
         'default' => 'inactive',
         'exclude' => true,
         'options' => ['active', 'inactive'],
-        'reference' => $GLOBALS['TL_LANG']['tl_page']['reference']['hyphenation'] ?? null,
+        'reference' => &$GLOBALS['TL_LANG']['tl_page']['reference']['hyphenation'],
         'eval' => ['includeBlankOption' => true, 'tl_class' => 'w50'],
         'sql' => "char(8) NOT NULL default ''",
     ],


### PR DESCRIPTION
Return `null` for undefined array keys to prevent php8 warnings in dev mode.