### PR TITLE
Ready for Contao 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         "issues": "https://github.com/heimrichhannot/contao-hyphenator-bundle/issues"
     },
     "require": {
-        "php": "^7.1 || ^8.0",
-        "contao/core-bundle": "^4.4",
+        "php": "^7.4 || ^8.0",
+        "contao/core-bundle": "^4.4 || ^5.0",
         "wa72/htmlpagedom": "^1.3 || ^2.0",
         "heimrichhannot/contao-multi-column-editor-bundle": "^2.0",
-        "heimrichhannot/contao-utils-bundle": "^2.16",
+        "heimrichhannot/contao-utils-bundle": "^2.16 || ^3.0",
         "vanderlee/syllable": "^1.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,17 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "contao/core-bundle": "^4.4 || ^5.0",
-        "wa72/htmlpagedom": "^1.3 || ^2.0",
+        "ext-libxml": "*",
+        "contao/core-bundle": "^4.13 || ^5.0",
+        "wa72/htmlpagedom": "^1.3 || ^2.0 || ^3.0",
         "heimrichhannot/contao-multi-column-editor-bundle": "^2.0",
         "heimrichhannot/contao-utils-bundle": "^2.16 || ^3.0",
         "vanderlee/syllable": "^1.5"
     },
     "require-dev": {
-        "contao/test-case": "1.1.* || ^2 || ^3 || ^4",
+        "contao/test-case": "1.1.* || ^2 || ^3 || ^4 || ^5",
         "contao/manager-plugin": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.2",
+        "friendsofphp/php-cs-fixer": "^2.2 || ^3.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -19,7 +19,7 @@ class Plugin implements BundlePluginInterface
     /**
      * {@inheritdoc}
      */
-    public function getBundles(ParserInterface $parser)
+    public function getBundles(ParserInterface $parser): array
     {
         return [
             BundleConfig::create(HeimrichHannotContaoHyphenatorBundle::class)->setLoadAfter([ContaoCoreBundle::class]),

--- a/src/DependencyInjection/HyphenatorExtension.php
+++ b/src/DependencyInjection/HyphenatorExtension.php
@@ -18,7 +18,7 @@ class HyphenatorExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $container->setParameter(Configuration::ROOT_ID, $this->processConfiguration($configuration, $configs));
@@ -27,7 +27,7 @@ class HyphenatorExtension extends Extension
         $loader->load('services.yml');
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return Configuration::ROOT_ID;
     }

--- a/src/EventListener/FrontendPageListener.php
+++ b/src/EventListener/FrontendPageListener.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * Copyright (c) 2021 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later

--- a/src/HeimrichHannotContaoHyphenatorBundle.php
+++ b/src/HeimrichHannotContaoHyphenatorBundle.php
@@ -9,6 +9,7 @@
 namespace HeimrichHannot\HyphenatorBundle;
 
 use HeimrichHannot\HyphenatorBundle\DependencyInjection\HyphenatorExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class HeimrichHannotContaoHyphenatorBundle extends Bundle
@@ -16,7 +17,7 @@ class HeimrichHannotContaoHyphenatorBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new HyphenatorExtension();
     }

--- a/src/Hyphenator/FrontendHyphenator.php
+++ b/src/Hyphenator/FrontendHyphenator.php
@@ -9,16 +9,11 @@
 namespace HeimrichHannot\HyphenatorBundle\Hyphenator;
 
 use Contao\Config;
-use Contao\Database;
 use Contao\PageModel;
 use Contao\StringUtil;
-use Contao\System;
 use HeimrichHannot\HyphenatorBundle\Source\File;
 use HeimrichHannot\UtilsBundle\Util\Utils;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Vanderlee\Syllable\Syllable;
 use Wa72\HtmlPageDom\HtmlPageCrawler;
 
@@ -30,13 +25,13 @@ class FrontendHyphenator
      * @var array
      */
     protected $voidElements = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
-    private ParameterBag $parameterBag;
+    private ParameterBagInterface $parameterBag;
     private Utils $utils;
 
     /**
      * Request constructor.
      */
-    public function __construct(ParameterBag $parameterBag, Utils $utils)
+    public function __construct(ParameterBagInterface $parameterBag, Utils $utils)
     {
         $this->parameterBag = $parameterBag;
         $this->utils = $utils;
@@ -69,7 +64,7 @@ class FrontendHyphenator
         // prevent unescape unicode html entities (email obfuscation)
         $strBuffer = preg_replace('/&(#+[x0-9a-fA-F]+);/', '&_$1;', $strBuffer);
 
-        Syllable::setCacheDir(System::getContainer()->getParameter('kernel.cache_dir'));
+        Syllable::setCacheDir($this->parameterBag->get('kernel.cache_dir'));
 
         $languageMapping = Config::get('hyphenator_locale_language_mapping');
 
@@ -122,7 +117,7 @@ class FrontendHyphenator
                 $skipTagCache = [];
                 $skipTagCacheIndex = 0;
 
-                $skipTags = System::getContainer()->getParameter('huh_hyphenator')['skip_tags'];
+                $skipTags =  $this->parameterBag->get('huh_hyphenator')['skip_tags'];
 
                 foreach ($skipTags as $tag) {
                     if (in_array($tag, $this->voidElements)) {
@@ -150,7 +145,7 @@ class FrontendHyphenator
 
                 // if html contains nested tags, use the hyphenateHtml that excludes HTML tags and attributes
                 libxml_use_internal_errors(true); // disable error reporting when potential using HTML5 tags
-                $html = $h->hyphenateHtmlText('<?xml encoding="utf-8" ?>'.$html);
+                $html = $h->hyphenateHtml('<?xml encoding="utf-8" ?>'.$html);
                 libxml_clear_errors();
 
                 // replace skipped tags

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,9 +4,22 @@ services:
     class: HeimrichHannot\HyphenatorBundle\Hyphenator\FrontendHyphenator
     public: true
     autowire: true
+    autoconfigure: true
+
   HeimrichHannot\HyphenatorBundle\Hyphenator\FrontendHyphenator: "@huh.hyphenator.frontend"
 
   huh.hyphenator.frontendPageListener:
     class: HeimrichHannot\HyphenatorBundle\EventListener\FrontendPageListener
     public: true
     autowire: true
+    autoconfigure: true
+    deprecated:
+      message: 'The "%service_id%" service is deprecated.'
+      package: 'heimrichhannot/contao-hyphenator-bundle'
+      version: '1.12'
+
+  HeimrichHannot\HyphenatorBundle\EventListener\:
+    resource: '../../EventListener/*'
+    public: true
+    autowire: true
+    autoconfigure: true

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Contao Open Source CMS
  *
@@ -9,9 +10,13 @@
  * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
  */
 
+use Contao\System;
+use HeimrichHannot\UtilsBundle\Util\Utils;
+
 /**
  * Config
  */
+
 $GLOBALS['TL_CONFIG']['hyphenator_tags']             = 'h1:not(:empty):not(.hyphen-none), h2:not(:empty):not(.hyphen-none), h3:not(:empty):not(.hyphen-none), h4:not(:empty):not(.hyphen-none), h5:not(:empty):not(.hyphen-none), h6:not(:empty):not(.hyphen-none), p:not(:empty):not(.hyphen-none), a:not(:empty):not(.hyphen-none), dt:not(:empty):not(.hyphen-none), dd:not(:empty):not(.hyphen-none)';
 $GLOBALS['TL_CONFIG']['hyphenator_wordMin']          = 10;
 $GLOBALS['TL_CONFIG']['hyphenator_hyphenedLeftMin']  = 6;
@@ -31,6 +36,6 @@ $GLOBALS['TL_HOOKS']['modifyFrontendPage'][] = ['huh.hyphenator.frontendPageList
 /**
  * Css
  */
-if (System::getContainer()->get('huh.utils.container')->isFrontend()) {
+if (System::getContainer()->get(Utils::class)->container()->isFrontend()) {
     $GLOBALS['TL_USER_CSS']['hyphenator'] = 'bundles/heimrichhannotcontaohyphenator/css/hyphenator.min.css|static';
 }

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -11,6 +11,7 @@
  */
 
 use Contao\System;
+use HeimrichHannot\HyphenatorBundle\EventListener\FrontendPageListener;
 use HeimrichHannot\UtilsBundle\Util\Utils;
 
 /**
@@ -31,7 +32,7 @@ $GLOBALS['TL_CONFIG']['hyphenator_locale_language_mapping']['cz'] = 'cs';
 /**
  * Hooks
  */
-$GLOBALS['TL_HOOKS']['modifyFrontendPage'][] = ['huh.hyphenator.frontendPageListener', 'modifyFrontendPage'];
+$GLOBALS['TL_HOOKS']['modifyFrontendPage'][] = [FrontendPageListener::class, 'modifyFrontendPage'];
 
 /**
  * Css

--- a/tests/ContaoManager/PluginTest.php
+++ b/tests/ContaoManager/PluginTest.php
@@ -32,7 +32,7 @@ class PluginTest extends ContaoTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/DependencyInjection/HyphenatorExtensionTest.php
+++ b/tests/DependencyInjection/HyphenatorExtensionTest.php
@@ -18,7 +18,7 @@ class HyphenatorExtensionTest extends ContaoTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));

--- a/tests/EventListener/FrontendPageListenerTest.php
+++ b/tests/EventListener/FrontendPageListenerTest.php
@@ -23,7 +23,7 @@ class FrontendPageListenerTest extends ContaoTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Hyphenator/FrontendHyphenatorTest.php
+++ b/tests/Hyphenator/FrontendHyphenatorTest.php
@@ -24,7 +24,7 @@ class FrontendHyphenatorTest extends ContaoTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Getestet. Funktioniert.

Aber! Deprecation von vanderlee\Syllable in src/Hyphenator/FrontendHyphenator.php λ  #148: Syllable::hyphenateHtml(...) deprecated ... funktioniert nicht mit vorgeschlagenem Ersatz Syllable::hyphenateHtmlText(...)